### PR TITLE
Add option to disable the wireless interface when connected to prevent audio dropouts

### DIFF
--- a/bt_speaker.py
+++ b/bt_speaker.py
@@ -26,6 +26,9 @@ default_config = u'''
 play_command = aplay -f cd -
 connect_command = ogg123 /usr/share/sounds/freedesktop/stereo/service-login.oga
 disconnect_command = ogg123 /usr/share/sounds/freedesktop/stereo/service-logout.oga
+disable_wifi_on_connect = yes
+wifi_down_command = ifconfig wlan0 down
+wifi_up_command = ifconfig wlan0 up
 
 [bluez]
 device_path = /org/bluez/hci0
@@ -98,9 +101,13 @@ class AutoAcceptSingleAudioAgent(BTAgent):
         if bool(self.connected):
             print("Hiding adapter from all devices.")
             self.adapter.set_property('Discoverable', False)
+            if config.getboolean('bt_speaker', 'disable_wifi_on_connect'):
+                subprocess.Popen(config.get('bt_speaker', 'wifi_down_command'), shell=True)
         else:
             print("Showing adapter to all devices.")
             self.adapter.set_property('Discoverable', True)
+            if config.getboolean('bt_speaker', 'disable_wifi_on_connect'):
+                subprocess.Popen(config.get('bt_speaker', 'wifi_up_command'), shell=True)
 
     def auto_accept_one(self, method, device, uuid):
         if not BTUUID(uuid).uuid in self.allowed_uuids: return False

--- a/bt_speaker.py
+++ b/bt_speaker.py
@@ -26,7 +26,7 @@ default_config = u'''
 play_command = aplay -f cd -
 connect_command = ogg123 /usr/share/sounds/freedesktop/stereo/service-login.oga
 disconnect_command = ogg123 /usr/share/sounds/freedesktop/stereo/service-logout.oga
-disable_wifi_on_connect = yes
+disable_wifi_on_connect = no
 wifi_down_command = ifconfig wlan0 down
 wifi_up_command = ifconfig wlan0 up
 

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ if [ -d bt-speaker ]; then
   cd bt-speaker && git pull
 else
   echo "Downloading bt-speaker..."
-  git clone https://github.com/c-larsen/bt-speaker.git
+  git clone https://github.com/lukasjapan/bt-speaker.git
 fi
 echo "done."
 

--- a/install.sh
+++ b/install.sh
@@ -8,14 +8,6 @@ apt-get update
 apt-get install git bluez python python-gobject python-cffi python-dbus python-alsaaudio python-configparser sound-theme-freedesktop vorbis-tools
 echo "done."
 
-# Add btspeaker user if not exist already
-echo
-echo "Adding btspeaker user..."
-id -u btspeaker &>/dev/null || useradd btspeaker -G audio
-# Also add user to bluetooth group if it exists (required in debian stretch)
-getent group bluetooth &>/dev/null && usermod -a -G bluetooth btspeaker
-echo "done."
-
 # Download bt-speaker to /opt (or update if already present)
 echo
 cd /opt
@@ -24,9 +16,22 @@ if [ -d bt-speaker ]; then
   cd bt-speaker && git pull
 else
   echo "Downloading bt-speaker..."
-  git clone https://github.com/lukasjapan/bt-speaker.git
+  git clone https://github.com/c-larsen/bt-speaker.git
 fi
 echo "done."
+
+if [ $1 != "root" ]; then
+  # Add btspeaker user if not exist already
+  echo
+  echo "Adding btspeaker user..."
+  id -u btspeaker &>/dev/null || useradd btspeaker -G audio
+  # Also add user to bluetooth group if it exists (required in debian stretch)
+  getent group bluetooth &>/dev/null && usermod -a -G bluetooth btspeaker
+  echo "done."
+else
+  #Change the service script to run as root instead
+  sed -i -e 's/btspeaker/root/g' /opt/bt-speaker/bt_speaker.service
+fi
 
 # Install and start bt-speaker daemon
 echo


### PR DESCRIPTION
Added an option for the user to have the daemon automatically disable the wireless interface (default WLAN0) when a device is connected and enable it again when disconnected. This is to prevent the known problems with audio stuttering and dropouts when streaming audio via bluetooth while the WLAN interface is active (https://github.com/lukasjapan/bt-speaker/issues/4)
 