### PR TITLE
Added functionality to support GPIO DAC and control power of media system

### DIFF
--- a/bt_speaker.py
+++ b/bt_speaker.py
@@ -17,6 +17,10 @@ import alsaaudio
 import math
 import configparser
 import io
+import threading
+import time
+import requests
+
 
 BTSPEAKER_CONFIG_FILE = '/etc/bt_speaker/config.ini'
 
@@ -29,6 +33,12 @@ disconnect_command = ogg123 /usr/share/sounds/freedesktop/stereo/service-logout.
 
 [bluez]
 device_path = /org/bluez/hci0
+discoverable = 0
+
+[sonoff]
+timeout = 15
+url_switch_on = http://192.168.1.42/control?cmd=event,T1
+url_switch_off = http://192.168.1.42/control?cmd=event,T0
 
 [alsa]
 mixer = PCM
@@ -47,6 +57,7 @@ class PipedSBCAudioSinkWithAlsaVolumeControl(SBCAudioSink):
     """
     def __init__(self, path='/endpoint/a2dpsink',
                        command=config.get('bt_speaker', 'play_command'),
+                       btsettings=config.get('bluez', 'discoverable'),
                        alsa_control=config.get('alsa', 'mixer'),
                        alsa_id=int(config.get('alsa', 'id')),
                        alsa_cardindex=int(config.get('alsa', 'cardindex')),
@@ -55,27 +66,30 @@ class PipedSBCAudioSinkWithAlsaVolumeControl(SBCAudioSink):
         # Start process
         self.process = subprocess.Popen(command, shell=True, bufsize=buf_size, stdin=subprocess.PIPE)
         # Hook into alsa service for volume control
-        self.alsamixer = alsaaudio.Mixer(control=alsa_control,
-                                         id=alsa_id,
-                                         cardindex=alsa_cardindex)
+#        self.alsamixer = alsaaudio.Mixer(control=alsa_control,
+#                                         id=alsa_id,
+#                                         cardindex=alsa_cardindex)
 
     def raw_audio(self, data):
         # pipe to the play command
         self.process.stdin.write(data)
 
     def volume(self, new_volume):
-        # normalize volume
-        volume = float(new_volume) / 127.0
+        if alsa_control != "None":
+            # normalize volume
+            volume = float(new_volume) / 127.0
 
-        print("Volume changed to %i%%" % (volume * 100.0))
+            print("Volume changed to %i%%" % (volume * 100.0))
 
-        # it looks like the value passed to alsamixer sets the volume by 'power level'
-        # to adjust to the (human) perceived volume, we have to square the volume
-        # @todo check if this only applies to the raspberry pi or in general (or if i got it wrong)
-        volume = math.pow(volume, 1.0/3.0)
+            # it looks like the value passed to alsamixer sets the volume by 'power level'
+            # to adjust to the (human) perceived volume, we have to square the volume
+            # @todo check if this only applies to the raspberry pi or in general (or if i got it wrong)
+            volume = math.pow(volume, 1.0/3.0)
 
-        # alsamixer takes a percent value as integer from 0-100
-        self.alsamixer.setvolume(int(volume * 100.0))
+            # alsamixer takes a percent value as integer from 0-100
+            self.alsamixer.setvolume(int(volume * 100.0))
+        else:
+            print("Volume control disabled for DAC device. Set mixer value to None")
 
 class AutoAcceptSingleAudioAgent(BTAgent):
     """
@@ -84,23 +98,56 @@ class AutoAcceptSingleAudioAgent(BTAgent):
     This 'first comes first served' is not necessarily the 'bluetooth way' of
     connecting devices but the easiest to implement.
     """
+
     def __init__(self, connect_callback, disconnect_callback):
         BTAgent.__init__(self, cb_notify_on_authorize=self.auto_accept_one)
         self.adapter = BTAdapter(config.get('bluez', 'device_path'))
         self.allowed_uuids = [ SERVICES["AdvancedAudioDistribution"].uuid, SERVICES["AVRemoteControl"].uuid ]
         self.connected = None
+        self.mediaStatus = None
+        self.timeout = threading.Timer(0, None)
+        self.thread = threading.Thread(None)
+        self.timeout_value = int(config.get('sonoff', 'timeout'))
         self.tracked_devices =  []
         self.connect_callback = connect_callback
         self.disconnect_callback = disconnect_callback
         self.update_discoverable()
+        self.mediaPower()
 
     def update_discoverable(self):
-        if bool(self.connected):
-            print("Hiding adapter from all devices.")
-            self.adapter.set_property('Discoverable', False)
+        if config.get('bluez', 'discoverable') == '1':
+            if bool(self.connected):
+                print("Hiding adapter from all devices.")
+                self.adapter.set_property('Discoverable', False)
+            else:
+                print("Showing adapter to all devices.")
+                self.adapter.set_property('Discoverable', True)
         else:
-            print("Showing adapter to all devices.")
-            self.adapter.set_property('Discoverable', True)
+            print("Hiding from everywhere as set.")
+            self.adapter.set_property('Discoverable', False)
+
+    def mediaPower(self):
+        url_switch_on = config.get('sonoff', 'url_switch_on')
+        url_switch_off = config.get('sonoff', 'url_switch_off')
+
+        if bool(self.connected) and not bool(self.mediaStatus):
+            print("Power on media system")
+            self.mediaStatus = True
+            self.make_request(url_switch_on)
+        elif bool(self.connected) and bool(self.mediaStatus):
+            print("Media system already on. Do nothing")
+        else:
+            print("Power down media system")
+            self.mediaStatus = False
+            self.make_request(url_switch_off)
+
+    def make_request(self, url):
+        response = requests.post(url, timeout=(3.05, 5))
+        print(response.status_code) # to get rid of it
+        if response.status_code == 200:
+            print("Controller switch complete!")
+        else:
+            print("Controller FAILED to complete!!!")
 
     def auto_accept_one(self, method, device, uuid):
         if not BTUUID(uuid).uuid in self.allowed_uuids: return False
@@ -128,12 +175,17 @@ class AutoAcceptSingleAudioAgent(BTAgent):
             self.connected = device
             self.update_discoverable()
             self.connect_callback()
+            self.timeout.cancel()
+            self.mediaPower()
 
         elif self.connected and not bool(properties['Connected']):
             print("Device disconnected. device=%s" % device)
             self.connected = None
             self.update_discoverable()
             self.disconnect_callback()
+            print("Starting timer for %s second(s) to turn off media system" % self.timeout_value)
+            self.timeout = threading.Timer(self.timeout_value, self.mediaPower)
+            self.timeout.start()
 
 def setup_bt():
     # register sink and media endpoint

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -e
 
 echo "Installing dependencies..."
 apt-get update
-apt-get install git bluez python python-gobject python-cffi python-dbus python-alsaaudio python-configparser sound-theme-freedesktop vorbis-tools
+apt-get install git bluez python python-requests python-gobject python-cffi python-dbus python-alsaaudio python-configparser sound-theme-freedesktop vorbis-tools
 echo "done."
 
 # Add btspeaker user if not exist already


### PR DESCRIPTION
Hello,
Great project however I faced some issues which I tried to fix and committed so project would be more universal. I have RaspberryPi 2 with PHAT DAC which give way better sound quality than integrated sound card. Pull request will cover:
-  PHAT DAC does not support ALSA volume control whilst I had to make it flexible by adding None value handler. If I am not wrong this will be common across most of DAC's and Amplifiers that connect via GPIO 
-  For security reasons BT-Speaker should now allow to set discovery to false after you paired all devices you want. Basically for setup you can use default functionality (discovery on after someone disconnect) but once paired with devices discovery mode should be off as it would allow to connect others you don't want to
-  Some TV's will not recognise BT-Speaker as it will filter out it by class. Added a bit of manual to README how to overcome it. Would be nice late to collaborate to BT-Manager and to implement Class parameter change
-  Importantly added functionality to support house automation solutions. Specifically choose Sonoff device which is easy to control via http post requests after flashing ESP Easy firmware but this can be adopted to any other. Important function over here is timeout handling. Although connect and disconnect commands are great they will not handle the application workflow which can turn into uncontrolled turn off and on of your media system. It will not allow user to add a timeout value after which if no one is connected to BT-Speaker it will turn off the media system and turn it on again if someone connects.  